### PR TITLE
Fix tests

### DIFF
--- a/src/test/.env
+++ b/src/test/.env
@@ -1,5 +1,22 @@
+# this file defines environment variables used in tests
+
+# this is necessary to run the tests with ts-node
 TS_NODE_FILES=true
+
+# optional: set the Firefox executable and profile to be used in the tests
 # FIREFOX_EXECUTABLE=/usr/bin/firefox
+# FIREFOX_PROFILE=debug
+
+# the tests can't detect which version of Firefox is used and what features it supports, so we declare the features here:
+
+# the behavior when stepping out of a function changed in Firefox 66
 NEW_STEP_OUT_BEHAVIOR=true
+
+# Firefox 66 stopped supporting server-side sourcemaps 
+SERVER_SIDE_SOURCEMAPS=false
+
+# the protocol for setting breakpoints changed in Firefox 67
 NEW_BREAKPOINT_PROTOCOL=true
+
+# watchpoints support should be introduced in Firefox 70
 WATCHPOINTS=false

--- a/src/test/sourceMapUtil.ts
+++ b/src/test/sourceMapUtil.ts
@@ -40,8 +40,6 @@ export async function testSourcemaps(
 	await util.runCommandAndReceiveStoppedEvent(dc, () => dc.continueRequest({ threadId }));
 
 	await checkDebuggeeState(dc, threadId, gPath, 5, 'y', '4');
-
-	await dc.stop();
 }
 
 async function checkDebuggeeState(

--- a/src/test/testGulpSourceMaps.ts
+++ b/src/test/testGulpSourceMaps.ts
@@ -18,11 +18,16 @@ const TESTDATA_PATH = path.join(__dirname, '../../testdata/web/sourceMaps/script
 describe('Gulp sourcemaps: The debugger', function() {
 
 	let dc: DebugClient | undefined;
+	let targetDir: string | undefined;
 
 	afterEach(async function() {
 		if (dc) {
 			await dc.stop();
 			dc = undefined;
+		}
+		if (targetDir) {
+			await fs.remove(targetDir);
+			targetDir = undefined;
 		}
 	});
 
@@ -57,18 +62,17 @@ describe('Gulp sourcemaps: The debugger', function() {
 
 		it(descr, async function() {
 
-			let { targetDir, srcDir, buildDir } = await prepareTargetDir(bundleScripts, separateBuildDir);
+			const targetPaths = await prepareTargetDir(bundleScripts, separateBuildDir);
+			targetDir = targetPaths.targetDir;
 
-			await build(buildDir, minifyScripts, bundleScripts, embedSourceMap, separateBuildDir);
+			await build(targetPaths.buildDir, minifyScripts, bundleScripts, embedSourceMap, separateBuildDir);
 
 			dc = await util.initDebugClient('', true, {
- 				file: path.join(buildDir, 'index.html'),
+ 				file: path.join(targetPaths.buildDir, 'index.html'),
  				sourceMaps
  			});
  
-			await sourceMapUtil.testSourcemaps(dc, srcDir);
-
-			await fs.remove(targetDir);
+			await sourceMapUtil.testSourcemaps(dc, targetPaths.srcDir);
 		});
 	}}}}}
 });

--- a/src/test/testGulpSourceMaps.ts
+++ b/src/test/testGulpSourceMaps.ts
@@ -55,7 +55,7 @@ describe('Gulp sourcemaps: The debugger', function() {
 		}
 
 		// server-side source-maps are not supported with Firefox >= 66.0
-		if ((process.env['NEW_STEP_OUT_BEHAVIOR'] === 'true') && (sourceMaps === 'server')) {
+		if ((process.env['SERVER_SIDE_SOURCEMAPS'] !== 'true') && (sourceMaps === 'server')) {
 			it.skip(descr);
 			continue;
 		}

--- a/src/test/testSkipFiles.ts
+++ b/src/test/testSkipFiles.ts
@@ -54,7 +54,7 @@ describe('Skipping files: The debugger', function() {
 		it(`should skip exceptions in blackboxed source-mapped files thrown immediately after loading with source-maps handled by the ${sourceMaps}`, async function() {
 
 			// server-side source-maps are not supported with Firefox >= 66.0
-			if ((process.env['NEW_STEP_OUT_BEHAVIOR'] === 'true') && (sourceMaps === 'server')) {
+			if ((process.env['SERVER_SIDE_SOURCEMAPS'] !== 'true') && (sourceMaps === 'server')) {
 				this.skip();
 				return;
 			}

--- a/src/test/testWebpackSourceMaps.ts
+++ b/src/test/testWebpackSourceMaps.ts
@@ -40,7 +40,7 @@ describe('Webpack sourcemaps: The debugger', function() {
 		}
 
 		// server-side source-maps are not supported with Firefox >= 66.0
-		if ((process.env['NEW_STEP_OUT_BEHAVIOR'] === 'true') && (sourceMaps === 'server')) {
+		if ((process.env['SERVER_SIDE_SOURCEMAPS'] !== 'true') && (sourceMaps === 'server')) {
 			it.skip(description);
 			continue;
 		}

--- a/src/test/testWebpackSourceMaps.ts
+++ b/src/test/testWebpackSourceMaps.ts
@@ -12,11 +12,16 @@ const TESTDATA_PATH = path.join(__dirname, '../../testdata/web/sourceMaps/module
 describe('Webpack sourcemaps: The debugger', function() {
 
 	let dc: DebugClient | undefined;
+	let targetDir: string | undefined;
 
 	afterEach(async function() {
 		if (dc) {
 			await dc.stop();
 			dc = undefined;
+		}
+		if (targetDir) {
+			await fs.remove(targetDir);
+			targetDir = undefined;
 		}
 	});
 
@@ -53,8 +58,6 @@ describe('Webpack sourcemaps: The debugger', function() {
 			});
 
 			await sourceMapUtil.testSourcemaps(dc, targetDir, 1);
-
-			await fs.remove(targetDir);
 		});
 	}}
 });

--- a/src/test/util.ts
+++ b/src/test/util.ts
@@ -21,6 +21,10 @@ export async function initDebugClient(
 		launchArgs.firefoxExecutable = process.env['FIREFOX_EXECUTABLE'];
 	}
 
+	if (process.env['FIREFOX_PROFILE']) {
+		launchArgs.profile = process.env['FIREFOX_PROFILE'];
+	}
+
 	if (extraLaunchArgs !== undefined) {
 		launchArgs = Object.assign(launchArgs, extraLaunchArgs);
 	}
@@ -66,6 +70,10 @@ export async function initDebugClientForAddon(
 
 	if (process.env['FIREFOX_EXECUTABLE']) {
 		dcArgs.firefoxExecutable = process.env['FIREFOX_EXECUTABLE'];
+	}
+
+	if (process.env['FIREFOX_PROFILE']) {
+		dcArgs.profile = process.env['FIREFOX_PROFILE'];
 	}
 
 	let dc = new DebugClient('node', './dist/adapter.bundle.js', 'firefox');


### PR DESCRIPTION
The sourcemap tests contained a bug in the `afterEach()` function.
Furthermore I have added support for specifying a Firefox profile to use in tests.