### PR TITLE
Issue 139

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,7 @@ popup auto-hide" (`extension.firefox.enablePopupAutohide` / `disablePopupAutohid
   ```json
   "reloadOnChange": "${workspaceFolder}/lib/*.js"
   ```
+* `clearConsoleOnReload`: Clear the debug console in VS Code when the page is reloaded in Firefox.
 * `profileDir`, `profile`: You can specify a Firefox profile directory or the name of a profile
   created with the Firefox profile manager. The extension will create a copy of this profile in the
   system's temporary directory and modify the settings in this copy to allow remote debugging.

--- a/package.json
+++ b/package.json
@@ -421,6 +421,11 @@
                   "ignore": "**/node_modules/**"
                 }
               },
+              "clearConsoleOnReload": {
+                "type": "boolean",
+                "description": "Clear the debug console in VS Code when the page is reloaded in Firefox",
+                "default": false
+              },
               "pathMappings": {
                 "type": "array",
                 "description": "Additional mappings from URLs (as seen by Firefox) to filesystem paths (as seen by VS Code)",
@@ -639,6 +644,11 @@
                   "watch": "${workspaceFolder}/**/*.js",
                   "ignore": "**/node_modules/**"
                 }
+              },
+              "clearConsoleOnReload": {
+                "type": "boolean",
+                "description": "Clear the debug console in VS Code when the page is reloaded in Firefox",
+                "default": false
               },
               "pathMappings": {
                 "type": "array",

--- a/src/adapter/configuration.ts
+++ b/src/adapter/configuration.ts
@@ -25,6 +25,7 @@ export interface ParsedConfiguration {
 	pathMappings: PathMappings;
 	filesToSkip: RegExp[];
 	reloadOnChange?: NormalizedReloadConfiguration,
+	clearConsoleOnReload: boolean,
 	sourceMaps: 'client' | 'server';
 	showConsoleCallLocation: boolean;
 	liftAccessorsFromPrototypes: number;
@@ -164,12 +165,14 @@ export async function parseConfiguration(
 
 	let reloadOnChange = parseReloadConfiguration(config.reloadOnChange);
 
+	const clearConsoleOnReload = !!config.clearConsoleOnReload;
+
 	let sourceMaps = config.sourceMaps || 'client';
 	let showConsoleCallLocation = config.showConsoleCallLocation || false;
 	let liftAccessorsFromPrototypes = config.liftAccessorsFromPrototypes || 0;
 
 	return {
-		attach, launch, addon, pathMappings, filesToSkip, reloadOnChange,
+		attach, launch, addon, pathMappings, filesToSkip, reloadOnChange, clearConsoleOnReload,
 		sourceMaps, showConsoleCallLocation, liftAccessorsFromPrototypes
 	}
 }

--- a/src/adapter/firefoxDebugSession.ts
+++ b/src/adapter/firefoxDebugSession.ts
@@ -524,6 +524,11 @@ export class FirefoxDebugSession {
 		consoleActor.onConsoleAPICall(async (consoleEvent) => {
 			consoleActorLog.debug(`Console API: ${JSON.stringify(consoleEvent)}`);
 
+			if (consoleEvent.level === 'clear') {
+				this.sendEvent(new OutputEvent('\x1b[2J'));
+				return;
+			}
+
 			let category = (consoleEvent.level === 'error') ? 'stderr' :
 				(consoleEvent.level === 'warn') ? 'console' : 'stdout';
 

--- a/src/adapter/firefoxDebugSession.ts
+++ b/src/adapter/firefoxDebugSession.ts
@@ -385,6 +385,9 @@ export class FirefoxDebugSession {
 			this.sendEvent(new Event('removeSources', <RemoveSourcesEventBody>{
 				threadId: threadAdapter.id
 			}));
+			if (this.config.clearConsoleOnReload) {
+				this.sendEvent(new OutputEvent('\x1b[2J'));
+			}
 		});
 
 		if (tabId != null) {

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -35,6 +35,7 @@ export interface CommonConfiguration {
 	webRoot?: string;
 	reloadOnAttach?: boolean;
 	reloadOnChange?: ReloadConfiguration;
+	clearConsoleOnReload?: boolean;
 	pathMappings?: { url: string, path: string | null }[];
 	skipFiles?: string[];
 	showConsoleCallLocation?: boolean;


### PR DESCRIPTION
Adds support for clearing VS Code's debug console with `console.clear()` and (optionally) clearing it when the page is reloaded.