### PR TITLE
change the default ExceptionBreakpoints setting

### DIFF
--- a/src/adapter/firefoxDebugSession.ts
+++ b/src/adapter/firefoxDebugSession.ts
@@ -65,7 +65,7 @@ export class FirefoxDebugSession {
 	public readonly frames = new Registry<FrameAdapter>();
 	public readonly variablesProviders = new Registry<VariablesProvider>();
 
-	private exceptionBreakpoints: ExceptionBreakpoints = ExceptionBreakpoints.All;
+	private exceptionBreakpoints: ExceptionBreakpoints = ExceptionBreakpoints.Uncaught;
 
 	private reloadTabs = false;
 


### PR DESCRIPTION
only relevant if this isn't set initially due to a bug in VS Code (microsoft/vscode#84295)