### PR TITLE
don't throw on the empty setDataBreakpoints request that VS Code sends during initialization

### DIFF
--- a/src/adapter/firefoxDebugAdapter.ts
+++ b/src/adapter/firefoxDebugAdapter.ts
@@ -428,7 +428,11 @@ export class FirefoxDebugAdapter extends DebugAdapterBase {
 
 	protected async setDataBreakpoints(args: DebugProtocol.SetDataBreakpointsArguments): Promise<{ breakpoints: DebugProtocol.Breakpoint[] }> {
 		if (!this.session.dataBreakpointsManager) {
-			throw "Your version of Firefox doesn't support watchpoints / data breakpoints";
+			if (args.breakpoints.length === 0) {
+				return { breakpoints: [] };
+			} else {
+				throw "Your version of Firefox doesn't support watchpoints / data breakpoints";
+			}
 		}
 
 		await this.session.dataBreakpointsManager.setDataBreakpoints(args.breakpoints);


### PR DESCRIPTION
... otherwise the initialization is aborted and we don't get a setExceptionBreakpoints request (so we don't know if the user wants to break on exceptions or not).