### PR TITLE
add tabFilter configuration property

### DIFF
--- a/package.json
+++ b/package.json
@@ -520,6 +520,42 @@
                   ]
                 }
               },
+              "tabFilter": {
+                "description": "Only attach to tabs whose URL matches this",
+                "type": [
+                  "string",
+                  "array",
+                  "object"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "properties": {
+                  "include": {
+                    "description": "URLs to attach to",
+                    "type": [
+                      "string",
+                      "array"
+                    ],
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": "*"
+                  },
+                  "exclude": {
+                    "description": "URLs not to attach to",
+                    "type": [
+                      "string",
+                      "array"
+                    ],
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": []
+                  }
+                },
+                "default": "*"
+              },
               "showConsoleCallLocation": {
                 "type": "boolean",
                 "description": "Show the location of console API calls",
@@ -730,6 +766,42 @@
                 "default": [
                   "${workspaceFolder}/node_modules/**/*"
                 ]
+              },
+              "tabFilter": {
+                "description": "Only attach to tabs whose URL matches this",
+                "type": [
+                  "string",
+                  "array",
+                  "object"
+                ],
+                "items": {
+                  "type": "string"
+                },
+                "properties": {
+                  "include": {
+                    "description": "URLs to attach to",
+                    "type": [
+                      "string",
+                      "array"
+                    ],
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": "*"
+                  },
+                  "exclude": {
+                    "description": "URLs not to attach to",
+                    "type": [
+                      "string",
+                      "array"
+                    ],
+                    "items": {
+                      "type": "string"
+                    },
+                    "default": []
+                  }
+                },
+                "default": "*"
               },
               "showConsoleCallLocation": {
                 "type": "boolean",

--- a/src/common/configuration.ts
+++ b/src/common/configuration.ts
@@ -36,6 +36,7 @@ export interface CommonConfiguration {
 	webRoot?: string;
 	reloadOnAttach?: boolean;
 	reloadOnChange?: ReloadConfiguration;
+	tabFilter?: TabFilterConfiguration;
 	clearConsoleOnReload?: boolean;
 	pathMappings?: { url: string, path: string | null }[];
 	skipFiles?: string[];
@@ -53,6 +54,13 @@ export interface DetailedReloadConfiguration {
 	watch: string | string[];
 	ignore?: string | string[];
 	debounce?: number | boolean;
+}
+
+export type TabFilterConfiguration = string | string[] | DetailedTabFilterConfiguration;
+
+export interface DetailedTabFilterConfiguration {
+	include?: string | string[];
+	exclude?: string | string[];
 }
 
 export declare type LogLevel = 'Debug' | 'Info' | 'Warn' | 'Error';

--- a/src/test/testConfigurationParser.ts
+++ b/src/test/testConfigurationParser.ts
@@ -26,6 +26,7 @@ describe('The configuration parser', function() {
 		assert.equal(parsedConfiguration.addon, undefined);
 		assert.deepEqual(parsedConfiguration.filesToSkip, []);
 		assert.equal(parsedConfiguration.reloadOnChange, undefined);
+		assert.deepEqual(parsedConfiguration.tabFilter, { include: [ /.*/ ], exclude: [] });
 		assert.equal(parsedConfiguration.showConsoleCallLocation, false);
 		assert.equal(parsedConfiguration.liftAccessorsFromPrototypes, 0);
 		assert.equal(parsedConfiguration.suggestPathMappingWizard, true);
@@ -53,6 +54,7 @@ describe('The configuration parser', function() {
 		assert.equal(parsedConfiguration.addon, undefined);
 		assert.deepEqual(parsedConfiguration.filesToSkip, []);
 		assert.equal(parsedConfiguration.reloadOnChange, undefined);
+		assert.deepEqual(parsedConfiguration.tabFilter, { include: [ /.*/ ], exclude: [] });
 		assert.equal(parsedConfiguration.showConsoleCallLocation, false);
 		assert.equal(parsedConfiguration.liftAccessorsFromPrototypes, 0);
 		assert.equal(parsedConfiguration.suggestPathMappingWizard, true);
@@ -494,6 +496,79 @@ describe('The configuration parser', function() {
 		});
 
 		assert.equal(parsedConfiguration.filesToSkip.length, 1);
+	});
+
+	it('should create a corresponding ParsedTabFilterConfiguration if "tabFilter" is set to a string', async function() {
+
+		let parsedConfiguration = await parseConfiguration({
+			request: 'launch',
+			file: '/home/user/project/index.html',
+			tabFilter: 'http://localhost:3000'
+		});
+
+		assert.deepEqual(parsedConfiguration.tabFilter, {
+			include: [ /^http:\/\/localhost:3000$/ ],
+			exclude: []
+		});
+	});
+
+	it('should create a corresponding ParsedTabFilterConfiguration if "tabFilter" is set to a string array', async function() {
+
+		let parsedConfiguration = await parseConfiguration({
+			request: 'launch',
+			file: '/home/user/project/index.html',
+			tabFilter: [ 'http://localhost:3000', 'about:newtab' ]
+		});
+
+		assert.deepEqual(parsedConfiguration.tabFilter, {
+			include: [ /^http:\/\/localhost:3000$/, /^about:newtab$/ ],
+			exclude: []
+		});
+	});
+
+	it('should add "exclude" to a detailed "tabFilter" containing only "include"', async function() {
+
+		let parsedConfiguration = await parseConfiguration({
+			request: 'launch',
+			file: '/home/user/project/index.html',
+			tabFilter: { include: '*localhost*' }
+		});
+
+		assert.deepEqual(parsedConfiguration.tabFilter, {
+			include: [ /^.*localhost.*$/ ],
+			exclude: []
+		});
+	});
+
+	it('should add "include" to a detailed "tabFilter" containing only "exclude"', async function() {
+
+		let parsedConfiguration = await parseConfiguration({
+			request: 'launch',
+			file: '/home/user/project/index.html',
+			tabFilter: { exclude: 'https://developer.mozilla.org/*' }
+		});
+
+		assert.deepEqual(parsedConfiguration.tabFilter, {
+			include: [ /.*/ ],
+			exclude: [ /^https:\/\/developer\.mozilla\.org\/.*$/ ]
+		});
+	});
+
+	it('should copy a detailed "tabFilter"', async function() {
+
+		let parsedConfiguration = await parseConfiguration({
+			request: 'launch',
+			file: '/home/user/project/index.html',
+			tabFilter: {
+				include: [ '*localhost*' ],
+				exclude: [ 'https://developer.mozilla.org/*' ]
+			}
+		});
+
+		assert.deepEqual(parsedConfiguration.tabFilter, {
+			include: [ /^.*localhost.*$/ ],
+			exclude: [ /^https:\/\/developer\.mozilla\.org\/.*$/ ]
+		});
 	});
 
 	it('should copy the "showConsoleCallLocation" value', async function() {


### PR DESCRIPTION
By default we attach to all Firefox tabs, with this configuration property the user can configure which tabs to attach to.