### PR TITLE
Fixed messed up sorting for Arrays.

### DIFF
--- a/src/adapter/adapter/objectGrip.ts
+++ b/src/adapter/adapter/objectGrip.ts
@@ -88,7 +88,11 @@ export class ObjectGripAdapter implements VariablesProvider {
 			}
 		}
 
-		VariableAdapter.sortVariables(variables);
+		/** Array-Objects are already sorted, sorting them again as strings messes up the order */
+		let isArray = (prototypeAndProperties.prototype.type == 'object' && prototypeAndProperties.prototype.class == 'Array');
+		if (!isArray) {
+			VariableAdapter.sortVariables(variables);
+		}
 		VariableAdapter.sortVariables(symbolVariables);
 		VariableAdapter.sortVariables(accessorsFromPrototypes);
 		variables.push(...symbolVariables);


### PR DESCRIPTION
Currently Arrays with more than 10 elements are ordered like this:

1, 10, 11, 12, 2, 3, 4, 5, 6, 7, 8, 9
[Screenshot](https://i.imgur.com/zSyrdqm.png)

after patch it's correctly like this:

1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12
[Screenshot](https://i.imgur.com/qxWDtym.png)




