### PR TITLE
Version 2.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### Version 2.9.8
+* debug protocol update for Firefox 104
+* fix the build on MacOS
+
 ### Version 2.9.7
 * debug protocol update for Firefox 102
 

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firefox-debugadapter",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "author": "Holger Benl <hbenl@evandor.de>",
   "description": "Debug adapter for Firefox",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-firefox-debug",
   "displayName": "Debugger for Firefox",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "author": "Holger Benl <hbenl@evandor.de>",
   "publisher": "firefox-devtools",
   "description": "Debug your web application or browser extension in Firefox",

--- a/src/adapter/firefox/actorProxy/tab.ts
+++ b/src/adapter/firefox/actorProxy/tab.ts
@@ -184,8 +184,7 @@ export class TabActorProxy extends EventEmitter implements ActorProxy {
 					log.debug(`Worker ${worker.actor} started`);
 
 					workerActor = new WorkerActorProxy(
-						worker.actor, worker.url, !!worker.traits.doNotAttach,
-						this.enableCRAWorkaround, this.pathMapper, this.connection);
+						worker.actor, worker.url, this.enableCRAWorkaround, this.pathMapper, this.connection);
 					this.emit('workerStarted', workerActor);
 
 				}

--- a/src/adapter/firefox/actorProxy/worker.ts
+++ b/src/adapter/firefox/actorProxy/worker.ts
@@ -10,37 +10,16 @@ let log = Log.create('WorkerActorProxy');
 
 export class WorkerActorProxy extends BaseActorProxy {
 
-	private attachPromise?: Promise<string>;
 	private connectPromise?: Promise<[IThreadActorProxy, ConsoleActorProxy]>;
 
 	constructor(
 		name: string,
 		public readonly url: string,
-		private readonly doNotAttach: boolean,
 		private readonly enableCRAWorkaround: boolean,
 		private readonly pathMapper: PathMapper,
 		connection: DebugConnection
 	) {
 		super(name, ['attached', 'connected'], connection);
-	}
-
-	public attach(): Promise<string> {
-		if (this.doNotAttach) {
-			return Promise.resolve(this.url);
-		}
-
-		if (!this.attachPromise) {
-			log.debug(`Attaching worker ${this.name}`);
-
-			this.attachPromise = this.sendRequest<any, FirefoxDebugProtocol.WorkerAttachedResponse>(
-				{ type: 'attach' }
-			).then(response => response.url);
-			
-		} else {
-			log.warn('Attaching this worker has already been requested!');
-		}
-		
-		return this.attachPromise;
 	}
 
 	public connect(): Promise<[IThreadActorProxy, ConsoleActorProxy]> {

--- a/src/adapter/firefox/protocol.d.ts
+++ b/src/adapter/firefox/protocol.d.ts
@@ -145,9 +145,6 @@ declare namespace FirefoxDebugProtocol {
 		actor: string;
 		url: string;
 		type: number;
-		traits: {
-			doNotAttach?: boolean;
-		}
 	}
 
 	interface WorkerAttachedResponse extends TypedResponse {

--- a/src/adapter/firefoxDebugSession.ts
+++ b/src/adapter/firefoxDebugSession.ts
@@ -461,7 +461,6 @@ export class FirefoxDebugSession {
 
 	private async attachWorker(workerActor: WorkerActorProxy, tabId: number, workerId: number): Promise<void> {
 
-		await workerActor.attach();
 		let [threadActor, consoleActor] = await workerActor.connect();
 
 		log.debug(`Attached to worker ${workerActor.name}`);

--- a/src/extension/pathMappingWizard.ts
+++ b/src/extension/pathMappingWizard.ts
@@ -95,7 +95,7 @@ export async function createPathMappingForPath(
 	}
 
 	const message =
-		"This file's path isn't mapped to any url that was loaded by Firefox. " +
+		`This file's path (${vscPath}) isn't mapped to any url that was loaded by Firefox. ` +
 		"Either this file hasn't been loaded by Firefox yet or " +
 		"your debug configuration needs a pathMapping for this file - " +
 		"do you think the file has already been loaded and want to let the " +

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,8 @@ module.exports = {
 		]
 	},
 	externals: {
-		vscode: 'commonjs vscode'
+		vscode: 'commonjs vscode',
+		fsevents: 'commonjs fsevents'
 	},
 	output: {
 		path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
- removes worker attach: the `doNotAttach` trait was removed in Firefox 104 - it's no longer needed since ESR is now on version 102, so no version that we want to support requires worker attach anymore
- fixes the build on MacOS
- fixes #293