### PR TITLE
"Firefox: Reload add-on" doesn't reload web extension

### DIFF
--- a/src/adapter/adapter/addonManager.ts
+++ b/src/adapter/adapter/addonManager.ts
@@ -23,6 +23,7 @@ export class AddonManager {
 
 	private addonAttached = false;
 	private addonActor: TabActorProxy | undefined = undefined;
+	private webExtensionActor: WebExtensionActorProxy | undefined = undefined;
 
 	constructor(
 		private readonly enableCRAWorkaround: boolean,
@@ -53,11 +54,11 @@ export class AddonManager {
 	}
 
 	public async reloadAddon(): Promise<void> {
-		if (!this.addonActor) {
+		if (!this.webExtensionActor) {
 			throw 'Addon isn\'t attached';
 		}
 
-		await this.addonActor.reload();
+		await this.webExtensionActor.reload();
 	}
 
 	private async fetchAddonsAndAttach(rootActor: RootActorProxy, useConnect: boolean): Promise<void> {
@@ -73,14 +74,14 @@ export class AddonManager {
 				(async () => {
 
 					let consoleActor: ConsoleActorProxy;
-					let webExtensionActor = new WebExtensionActorProxy(
+					this.webExtensionActor = new WebExtensionActorProxy(
 						addon, this.enableCRAWorkaround, this.debugSession.pathMapper,
 						this.debugSession.firefoxDebugConnection);
 
 					if (useConnect) {
-						[this.addonActor, consoleActor] = await webExtensionActor.connect();
+						[this.addonActor, consoleActor] = await this.webExtensionActor.connect();
 					} else {
-						[this.addonActor, consoleActor] = await webExtensionActor.getTarget();
+						[this.addonActor, consoleActor] = await this.webExtensionActor.getTarget();
 					}
 
 					let threadAdapter = await this.debugSession.attachTabOrAddon(


### PR DESCRIPTION
# Problem

When I edit the code and reload the Firefox extension by "Firefox: Reload add-on", the changes are not applied.
This Pull Request solves this problem.

![2022-10-15_23h59_15](https://user-images.githubusercontent.com/16362824/195993419-23d215a2-f0b3-4003-ab22-107354920ffc.gif)

# Steps to reproduce

1. Create web extension project by `npm init webextension firefox-webext-test`.
2. Open project with Visual Studio Code.
3. Create `launch.json` in `.vscode` directory.
    <details><summary>Code</summary>

    ```json
    {
        "version": "0.2.0",
        "configurations": [
            {
                "type": "firefox",
                "request": "launch",
                "name": "Launch add-on",
                "addonPath": "${workspaceFolder}",
                "url": "https://developer.mozilla.org/"
            }
        ]
    }
    ```
    </details>
4. Replace the code in "content.js" with "alert("Test v1");".
5. Press F5 to launch Firefox and you will see "Test v1.
6. Replace the code in "content.js" with "alert("Test v2");".
7. Press Ctrl+Shift+P and select "Firefox: Reload add-on".
8. Reload the page in Firefox, it still keeps showing "Test v1"." It does not become "Test v2".