### PR TITLE
Set default localhost resolution to IPv4

### DIFF
--- a/src/adapter/util/net.ts
+++ b/src/adapter/util/net.ts
@@ -3,6 +3,7 @@ import * as fs from 'fs-extra';
 import * as net from 'net';
 import * as http from 'http';
 import * as https from 'https';
+import { setDefaultResultOrder } from 'dns';
 import fileUriToPath from 'file-uri-to-path';
 import dataUriToBuffer from 'data-uri-to-buffer';
 import { Log } from './log';
@@ -14,6 +15,7 @@ let log = Log.create('net');
  * connect to a TCP port
  */
 export function connect(port: number, host?: string): Promise<net.Socket> {
+	setDefaultResultOrder("ipv4first");
 	return new Promise<net.Socket>((resolve, reject) => {
 		let socket = net.connect(port, host || 'localhost');
 		socket.on('connect', () => resolve(socket));


### PR DESCRIPTION
While Firefox starts its debug server on IPv4 `localhost`, node defaults to IPv6 `::1` since node 17 (https://github.com/nodejs/node/issues/40537).

For this reason, on newer versions of node, vscode-firefox-debug responds with
```
Error on launch: connect ECONNREFUSED ::1:6000
```

This PR changes the default back to where it was before node v17.

This should fix #306 