### PR TITLE
Fix marketplace badge link and set version to 2.9.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### Version 2.9.10
+* fix marketplace badge link in the README
+
 ### Version 2.9.9
 * compatibility fix for Node 17 / VS Code 1.82
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 <h4 align="center">Debug your JavaScript code running in Firefox from VS Code.</h4>
 
 <p align="center">
-  <a href="https://marketplace.visualstudio.com/items?itemName=firefox-devtools.vscode-firefox-debug"><img src="https://vsmarketplacebadge.apphb.com/version/firefox-devtools.vscode-firefox-debug.svg?label=Debugger%20for%20Firefox" alt="Marketplace bagde"></a>
+  <a href="https://marketplace.visualstudio.com/items?itemName=firefox-devtools.vscode-firefox-debug"><img src="https://vsmarketplacebadges.dev/version/firefox-devtools.vscode-firefox-debug.png?label=Debugger%20for%20Firefox" alt="Marketplace bagde"></a>
 </p>
 
 A VS Code extension to debug web applications and extensions running in the [Mozilla Firefox browser](https://www.mozilla.org/en-US/firefox/developer/?utm_medium=vscode_extension&utm_source=devtools). [📦 Install from VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=firefox-devtools.vscode-firefox-debug).

--- a/dist/package.json
+++ b/dist/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firefox-debugadapter",
-  "version": "2.9.9",
+  "version": "2.9.10",
   "author": "Holger Benl <hbenl@evandor.de>",
   "description": "Debug adapter for Firefox",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-firefox-debug",
   "displayName": "Debugger for Firefox",
-  "version": "2.9.9",
+  "version": "2.9.10",
   "author": "Holger Benl <hbenl@evandor.de>",
   "publisher": "firefox-devtools",
   "description": "Debug your web application or browser extension in Firefox",


### PR DESCRIPTION
I had to update the badge link in the README because the VS Code Marketplace refused to publish the extension with the old link.
Since there were no code changes I've taken the liberty to already publish this.