### PR TITLE
Fix typescript error: upgrade node and vscode types

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -43,9 +43,9 @@
         "@types/gulp-sourcemaps": "^0.0.36",
         "@types/gulp-uglify": "^3.0.8",
         "@types/mocha": "^10.0.1",
-        "@types/node": "^10.17.60",
+        "@types/node": "^16.18.80",
         "@types/uuid": "^9.0.4",
-        "@types/vscode": "~1.40.0",
+        "@types/vscode": "~1.66.0",
         "babel-loader": "^9.1.3",
         "copy-webpack-plugin": "^11.0.0",
         "gulp": "^4.0.2",
@@ -66,7 +66,7 @@
         "webpack-cli": "^5.1.4"
       },
       "engines": {
-        "vscode": "^1.40.0"
+        "vscode": "^1.66.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -2490,9 +2490,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "version": "16.18.83",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.83.tgz",
+      "integrity": "sha512-TmBqzDY/GeCEmLob/31SunOQnqYE3ZiiuEh1U9o3HqE1E2cqKZQA5RQg4krEguCY3StnkXyDmCny75qyFLx/rA==",
       "dev": true
     },
     "node_modules/@types/uglify-js": {
@@ -2558,9 +2558,9 @@
       }
     },
     "node_modules/@types/vscode": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
-      "integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+      "integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
       "dev": true
     },
     "node_modules/@webassemblyjs/ast": {
@@ -14736,9 +14736,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "10.17.60",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
-      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw==",
+      "version": "16.18.83",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.83.tgz",
+      "integrity": "sha512-TmBqzDY/GeCEmLob/31SunOQnqYE3ZiiuEh1U9o3HqE1E2cqKZQA5RQg4krEguCY3StnkXyDmCny75qyFLx/rA==",
       "dev": true
     },
     "@types/uglify-js": {
@@ -14803,9 +14803,9 @@
       }
     },
     "@types/vscode": {
-      "version": "1.40.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.40.0.tgz",
-      "integrity": "sha512-5kEIxL3qVRkwhlMerxO7XuMffa+0LBl+iG2TcRa0NsdoeSFLkt/9hJ02jsi/Kvc6y8OVF2N2P2IHP5S4lWf/5w==",
+      "version": "1.66.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+      "integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
       "dev": true
     },
     "@webassemblyjs/ast": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "description": "Debug your web application or browser extension in Firefox",
   "icon": "icon.png",
   "engines": {
-    "vscode": "^1.40.0"
+    "vscode": "^1.66.0"
   },
   "categories": [
     "Debuggers"
@@ -62,9 +62,9 @@
     "@types/gulp-sourcemaps": "^0.0.36",
     "@types/gulp-uglify": "^3.0.8",
     "@types/mocha": "^10.0.1",
-    "@types/node": "^10.17.60",
+    "@types/node": "^16.18.80",
     "@types/uuid": "^9.0.4",
-    "@types/vscode": "~1.40.0",
+    "@types/vscode": "~1.66.0",
     "babel-loader": "^9.1.3",
     "copy-webpack-plugin": "^11.0.0",
     "gulp": "^4.0.2",

--- a/src/adapter/firefox/launch.ts
+++ b/src/adapter/firefox/launch.ts
@@ -65,8 +65,8 @@ export async function launchFirefox(launch: ParsedLaunchConfiguration): Promise<
 
 		childProc = spawn(launch.firefoxExecutable, launch.firefoxArgs, { env, detached: true });
 
-		childProc.stdout.on('data', () => undefined);
-		childProc.stderr.on('data', () => undefined);
+		childProc.stdout?.on('data', () => undefined);
+		childProc.stderr?.on('data', () => undefined);
 
 		childProc.unref();
 	}

--- a/src/adapter/firefox/transport.ts
+++ b/src/adapter/firefox/transport.ts
@@ -1,3 +1,4 @@
+import { Socket } from 'net';
 import { Log } from '../util/log';
 import { EventEmitter } from 'events';
 
@@ -16,7 +17,7 @@ export class DebugProtocolTransport extends EventEmitter {
 	private receivingHeader: boolean;
 
 	constructor(
-		private socket: SocketLike
+		private socket: Socket
 	) {
 		super();
 
@@ -85,11 +86,4 @@ export class DebugProtocolTransport extends EventEmitter {
 			this.socket.end();
 		});
 	}
-}
-
-export interface SocketLike {
-	on(event: string, listener: Function): EventEmitter;
-	write(buffer: Buffer): boolean;
-	write(str: string, encoding: string): boolean;
-	end(): void;
 }

--- a/src/extension/addPathMapping.ts
+++ b/src/extension/addPathMapping.ts
@@ -79,7 +79,7 @@ function _findLaunchConfig(): LaunchConfigReference | undefined {
 }
 
 export function findLaunchConfig(
-	workspaceFolders: vscode.WorkspaceFolder[],
+	workspaceFolders: readonly vscode.WorkspaceFolder[],
 	activeDebugSession: vscode.DebugSession
 ): LaunchConfigReference | undefined {
 

--- a/src/extension/loadedScripts/provider.ts
+++ b/src/extension/loadedScripts/provider.ts
@@ -7,8 +7,8 @@ export class LoadedScriptsProvider implements vscode.TreeDataProvider<TreeNode> 
 
 	private readonly root = new RootNode();
 
-	private readonly treeDataChanged = new vscode.EventEmitter<TreeNode>();
-	public readonly onDidChangeTreeData: vscode.Event<TreeNode>;
+	private readonly treeDataChanged = new vscode.EventEmitter<TreeNode | void>();
+	public readonly onDidChangeTreeData: vscode.Event<TreeNode | void>;
 
 	public constructor() {
 		this.onDidChangeTreeData = this.treeDataChanged.event;


### PR DESCRIPTION
In #342 I started using a new node API (`setDefaultResultOrder`) but the extension was still using types for an old node version that doesn't contain this API, resulting in a typescript error.
This PR updates the node types as well as the minimum supported VS Code version to one that includes a version of node that supports the new API (the node types should always correspond to the version of node included in the minimum supported VS Code version).
