### PR TITLE
Detect and catch failed threadGrip requests

### DIFF
--- a/src/adapter/firefox/actorProxy/objectGrip.ts
+++ b/src/adapter/firefox/actorProxy/objectGrip.ts
@@ -116,6 +116,12 @@ export class ObjectGripActorProxy implements ActorProxy {
 			log.warn(`No such actor ${this.grip.actor} - you will not be able to inspect this value; this is probably due to Firefox bug #1249962`);
 			this.pendingPrototypeAndPropertiesRequests.rejectAll('No such actor');
 
+
+		} else if (response['error'] && (typeof response['message'] === 'string') && response['message'].includes('threadGrip')) {
+
+			log.warn('threadGrip not implemented in Firefox');
+			this.pendingVoidRequests.rejectOne('threadGrip not implemented in Firefox');
+
 		} else {
 
 			log.warn("Unknown message from ObjectGripActor: " + JSON.stringify(response));

--- a/src/adapter/firefoxDebugAdapter.ts
+++ b/src/adapter/firefoxDebugAdapter.ts
@@ -414,15 +414,16 @@ export class FirefoxDebugAdapter extends DebugAdapterBase {
 
 			const provider = this.session.variablesProviders.find(args.variablesReference);
 			if (provider instanceof ObjectGripAdapter) {
-
-				provider.threadAdapter.threadLifetime(provider);
-				await provider.actor.threadLifetime();
-
-				return {
-					dataId: DataBreakpointsManager.encodeDataId(args.variablesReference, args.name),
-					description: args.name,
-					accessTypes: [ 'read', 'write' ]
-				};
+				try {
+					await provider.actor.threadLifetime();
+					provider.threadAdapter.threadLifetime(provider);
+	
+					return {
+						dataId: DataBreakpointsManager.encodeDataId(args.variablesReference, args.name),
+						description: args.name,
+						accessTypes: [ 'read', 'write' ]
+					};
+				} catch {}
 			}
 		}
 


### PR DESCRIPTION
Firefox 133 doesn't implement the `threadGrip` request used for data breakpoints. As a consequence `dataBreakpointInfo` requests from VS Code never resolve and VS Code doesn't show the context menu in the scopes panel (because the `dataBreakpointInfo` response is necessary to decide whether to add the data breakpoint entries to the menu).
With this patch the failing `threadGrip` requests are detected and caught in the `dataBreakpointInfo` request handler, so the context menu for the scopes panel works again (but doesn't offer data breakpoints).